### PR TITLE
Inherit Instance Parameters

### DIFF
--- a/carthage_aws/vm.py
+++ b/carthage_aws/vm.py
@@ -41,10 +41,6 @@ class AwsVm(AwsManaged, Machine):
         self.running = False
         self.closed = False
         self._operation_lock = asyncio.Lock()
-        self.key = self.model.key
-        self.imageid = self.model.imageid
-        self.size = self.model.size
-        self.id = None
         self._clear_ip_address = True
 
     def _find_ip_address(self):
@@ -124,11 +120,11 @@ class AwsVm(AwsManaged, Machine):
 
         try:
             r = self.connection.client.run_instances(
-                ImageId=self.imageid,
+                ImageId=self._gfi('aws_ami'),
                 MinCount=1,
                 MaxCount=1,
-                InstanceType=self.size,
-                KeyName=self.key,
+                InstanceType=self._gfi('aws_instance_type'),
+                KeyName=self._gfi('aws_key_name', default=None),
                 UserData=user_data,
                 NetworkInterfaces=network_interfaces,
                 TagSpecifications=[self.resource_tags],

--- a/tests/layout.py
+++ b/tests/layout.py
@@ -31,3 +31,7 @@ class test_layout(CarthageLayout, AwsDnsManagement):
         name="test-vm"
         cloud_init = True
         aws_instance_type = "t2.micro"
+
+    class does_not_exist(MachineModel):
+        aws_readonly = True
+        

--- a/tests/layout.py
+++ b/tests/layout.py
@@ -17,6 +17,8 @@ class test_layout(CarthageLayout, AwsDnsManagement):
     add_provider(machine_implementation_key, dependency_quote(AwsVm))
     add_provider(InjectionKey(AwsHostedZone),
                  when_needed(AwsHostedZone, name="autotest.photon.ac"))
+    aws_key_name = 'main'
+    aws_ami = "ami-06ed7917b75fcaf17"
 
     class our_net(NetworkModel):
         v4_config = V4Config(network="192.168.100.0/24")
@@ -28,6 +30,4 @@ class test_layout(CarthageLayout, AwsDnsManagement):
     class test_vm(MachineModel):
         name="test-vm"
         cloud_init = True
-        key = 'main'
-        imageid = "ami-06ed7917b75fcaf17"
-        size = "t2.micro"
+        aws_instance_type = "t2.micro"

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -34,3 +34,10 @@ async def test_start_machine(carthage_layout):
     layout.test_vm.machine.mob.terminate()
     
                            
+@async_test
+async def test_read_only(carthage_layout):
+    layout = carthage_layout
+    await layout.ainjector.get_instance_async(AwsConnection)
+    with pytest.raises(LookupError):
+        await layout.does_not_exist.machine.async_become_ready()
+        


### PR DESCRIPTION
I think we want to have more flexibility that requiring each model to specify all the parameters.  For example I expect that the AMI  ID is likely to be common across significant chunks of a layout.  This pull request implements support for that.  It's submitted as a pull request because it is a backward incompatible change and because it breaks existing layouts.
I recommend that we retire the example layout and just use tests/layout.yml  after merging this.

cc: @kdienes 