### PR TITLE
Add support for specifying private EC2 instance ip addresses

### DIFF
--- a/tests/layout.py
+++ b/tests/layout.py
@@ -35,6 +35,14 @@ class test_layout(CarthageLayout, AwsDnsManagement, AnsibleModelMixin):
         cloud_init = True
         aws_instance_type = "t2.micro"
 
+        class static_ip_net_config(NetworkConfigModel):
+            add('eth0', mac=None, net=InjectionKey("our_net"),
+                v4_config=V4Config(
+                    dhcp=False,
+                    address='192.168.100.237'
+                )
+            )
+
     class test_no_ready(MachineModel):
         name="test-vm-no-ready"
         cloud_init = True


### PR DESCRIPTION
This change allows specifying EC2 instance private IP addresses as follows:

class vm_test(MachineModel):
    name = 'test'
    class netconfig(NetworkConfigModel):
        add('eth-test', net=InjectionKey(net_test_key), mac=None, v4_config=V4Config(dhcp=False, address='10.0.0.7'))