### PR TITLE
Tag provider

### DIFF
--- a/carthage_aws/__init__.py
+++ b/carthage_aws/__init__.py
@@ -31,6 +31,9 @@ __all__ += ['image_provider', 'debian_ami_owner', 'AttachImageBuilderVolume', 'I
 from .ebs import AwsVolume
 __all__ += ['AwsVolume']
 
+from .tag import AwsTagsProvider
+__all__ += ['AwsTagsProvider']
+
 class AwsConfig(ConfigSchema, prefix = "aws"):
     #:aws_access_key_id
     access_key_id: ConfigString
@@ -48,7 +51,16 @@ class AwsConfig(ConfigSchema, prefix = "aws"):
     vpc_id: ConfigString
     #: CIDR block to allocate to created VPC
     vpc_cidr: IPv4Network = IPv4Network('192.168.0.0/16')
-    
+
+class AwsTags(ConfigSchema, prefix='aws.tags'):
+    #:carthage:cloudformation:stack_name:
+    stack_name: ConfigString
+
+    #:carthage:cloudformation:stack_id:
+    stack_id: ConfigString
+
+    #:carthage:cloudformation:logical_id:
+    logical_id: ConfigString
 
 @inject(injector=Injector)
 def enable_new_aws_connection(injector):

--- a/carthage_aws/tag.py
+++ b/carthage_aws/tag.py
@@ -1,0 +1,28 @@
+from carthage.config import ConfigLayout, config_key
+from carthage.dependency_injection import Injectable, InjectionKey, inject_autokwargs
+from carthage.modeling import Enclave
+
+from .network import AwsVirtualPrivateCloud, AwsSubnet
+
+__all__ = ['AwsTagsProvider']
+
+@inject_autokwargs(
+    logical_id=InjectionKey(config_key('aws.tags.logical_id'), _optional=True),
+    stack_id=InjectionKey(config_key('aws.tags.stack_id'), _optional=True),
+    stack_name=InjectionKey(config_key('aws.tags.stack_name'), _optional=True)
+)
+class AwsTagsProvider(Injectable):
+
+    cloudkw = ['logical_id', 'stack_id', 'stack_name']
+
+    def __init__(self, **kwargs):
+        self.tags = {}
+
+        for kw in self.cloudkw:
+            if kw in kwargs and kwargs[kw] is not None:
+                k = kwargs.pop(kw)
+                self._injection_autokwargs.remove(kw)
+                assert type(k) is str,f'{kw}={k} for {self} must be str'
+                self.tags[f'carthage:cloudformation:{kw}'] = k
+
+        super().__init__(**kwargs)

--- a/tests/console_config.yml
+++ b/tests/console_config.yml
@@ -2,6 +2,9 @@ plugins:
 - .
 aws:
   region: us-east-1
+  tags:
+    stack_name: 'test-stack-name'
+    stack_id: 'id-test-abc123'
 base_dir: /tmp/carthage-base
 checkout_dir: /tmp/carthage-base/checkout
 layout_name:  aws_test

--- a/tests/layout.py
+++ b/tests/layout.py
@@ -22,6 +22,8 @@ class test_layout(CarthageLayout, AwsDnsManagement, AnsibleModelMixin):
     #aws_key_name = 'main'
     add_provider(InjectionKey('aws_ami'), image_provider(owner=debian_ami_owner, name='debian-11-amd64-20220310-944'))
 
+    add_provider(InjectionKey(AwsTagsProvider), AwsTagsProvider)
+
     domain = "autotest.photon.ac"
     class our_net(NetworkModel):
         v4_config = V4Config(network="192.168.100.0/24")


### PR DESCRIPTION
Add support and tests for providing optional cloudformation-esque tags in config.yml like so:

```
aws:
  tags:
    stack_name: 'test-stack-name'
    stack_id: 'id-abc123'
    layout_id: 'layout-id-123'
```
This would create the following tags on all resources:
```
carthage:cloudformation:stack_name = 'test-stack-name'
carthage:cloudformation:stack_id = 'id-abc123'
carthage:cloudformation:layout_id = 'layout-id-123'
```