### PR TITLE
Pass list to update_record not single address

### DIFF
--- a/carthage_aws/dns.py
+++ b/carthage_aws/dns.py
@@ -192,7 +192,7 @@ class AwsDnsManagement(InjectableModel):
             logger.warning(f'Not setting DNS for {model}: {name} does not fall within {zone.name}')
         else:
             logger.debug(f'{name} is at {str(link.public_v4_address)}')
-            await zone.update_record((name, 'A', str(link.public_v4_address)),
+            await zone.update_record((name, 'A', [str(link.public_v4_address)]),
                                      ttl=30)
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
There is code in update_record to detect a single item being passed:

   if not isinstance(values, collections.abc.Sequence): values = (values,)

But since the IPv4 record is a string:

    >>> isinstance('aaa', collections.abc.Sequence)
   True

we don't get a very good error message.

I wasn't able to decide if I thought update_record should accept an IPv4Address or how to best fix the isinstance(), so I took the easy way out.