### PR TITLE
Enhance the pre-commit hook to not allow unlinted files in on accident.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+pylint/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-container  clean-container setup-githooks quality build-venv clean-venv test check
+.PHONY: build-container clean-container setup-githooks quality pylint build-venv clean-venv test check
 
 PYTHON := python3
 GIT_ROOT := $(shell git rev-parse --show-toplevel)

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,26 +1,52 @@
 #!/bin/sh
 
-
 exec 1>&2
 
-EXIT_STATUS=0
-FILES=$(git diff --cached --name-only --diff-filter=ACM HEAD| grep '\.py$' |tr "\n" " ")
-if [ -z "$FILES" ]; then
-    exit 0
+# Path to store the temp directory location
+TEMP_DIR_PATH_FILE=".git/temp_lint_dir"
+
+# Check if a previous temp directory exists
+if [ -f "$TEMP_DIR_PATH_FILE" ]; then
+	TEMP_DIR=$(cat "$TEMP_DIR_PATH_FILE")
+	if [ ! -d "$TEMP_DIR" ]; then
+		TEMP_DIR=$(mktemp -d)
+		echo "$TEMP_DIR" >"$TEMP_DIR_PATH_FILE"
+	fi
+else
+	TEMP_DIR=$(mktemp -d)
+	echo "$TEMP_DIR" >"$TEMP_DIR_PATH_FILE"
 fi
 
-make pylint FILES="$FILES"
+cleanup() {
+	if [ -f "$TEMP_DIR_PATH_FILE" ]; then
+		rm -f "$TEMP_DIR_PATH_FILE"
+	fi
+	rm -rf "$TEMP_DIR"
+}
 
+# Check for python files in the staging area
+FILES=$(git diff --cached --name-only --diff-filter=ACM HEAD | grep '\.py$')
+if [ -z "$FILES" ]; then
+	exit 0
+fi
+
+# Copy staged versions of files to the temporary directory
+for FILE in $FILES; do
+	mkdir -p "$TEMP_DIR/$(dirname "$FILE")"
+	git show :"$FILE" >"$TEMP_DIR/$FILE"
+done
+
+# Run pylint on the files in the temporary directory
+make pylint FILES="$TEMP_DIR/$FILES"
 PYLINT_EXIT=$?
 
 # If pylint exit status is not 0 or 30 (no issues or only warnings)
 if [ $PYLINT_EXIT -ne 0 ] && [ $PYLINT_EXIT -ne 30 ]; then
-	EXIT_STATUS=1
-fi
-
-if [ $EXIT_STATUS -ne 0 ]; then
 	echo "Commit failed: pylint checks did not pass."
+	echo "You can find the files that failed linting in $TEMP_DIR"
 	exit 1
+else
+	cleanup
 fi
 
 exit 0

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -16,12 +16,14 @@ if [ -z "$FILES" ]; then
 	exit 0
 fi
 
+PYLINT_FILES=""
 # Use git checkout-index to check out the files into the pylint directory
 for FILE in $FILES; do
 	git checkout-index --prefix="$PYLINT_DIR/" --force -- "$FILE"
+	PYLINT_FILES="$PYLINT_FILES $PYLINT_DIR/$FILE"
 done
 
-make pylint FILES="$PYLINT_DIR/$FILES"
+make pylint FILES="$PYLINT_FILES"
 PYLINT_EXIT=$?
 
 # If pylint exit status is not 0 or 30 (no issues or only warnings)

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -2,26 +2,12 @@
 
 exec 1>&2
 
-# Path to store the temp directory location
-TEMP_DIR_PATH_FILE=".git/temp_lint_dir"
+PYLINT_DIR="./pylint"
 
-# Check if a previous temp directory exists
-if [ -f "$TEMP_DIR_PATH_FILE" ]; then
-	TEMP_DIR=$(cat "$TEMP_DIR_PATH_FILE")
-	if [ ! -d "$TEMP_DIR" ]; then
-		TEMP_DIR=$(mktemp -d)
-		echo "$TEMP_DIR" >"$TEMP_DIR_PATH_FILE"
-	fi
-else
-	TEMP_DIR=$(mktemp -d)
-	echo "$TEMP_DIR" >"$TEMP_DIR_PATH_FILE"
-fi
+mkdir -p "$PYLINT_DIR"
 
 cleanup() {
-	if [ -f "$TEMP_DIR_PATH_FILE" ]; then
-		rm -f "$TEMP_DIR_PATH_FILE"
-	fi
-	rm -rf "$TEMP_DIR"
+	rm -rf "$PYLINT_DIR"
 }
 
 # Check for python files in the staging area
@@ -30,20 +16,18 @@ if [ -z "$FILES" ]; then
 	exit 0
 fi
 
-# Copy staged versions of files to the temporary directory
+# Use git checkout-index to check out the files into the pylint directory
 for FILE in $FILES; do
-	mkdir -p "$TEMP_DIR/$(dirname "$FILE")"
-	git show :"$FILE" >"$TEMP_DIR/$FILE"
+	git checkout-index --prefix="$PYLINT_DIR/" --force -- "$FILE"
 done
 
-# Run pylint on the files in the temporary directory
-make pylint FILES="$TEMP_DIR/$FILES"
+make pylint FILES="$PYLINT_DIR/$FILES"
 PYLINT_EXIT=$?
 
 # If pylint exit status is not 0 or 30 (no issues or only warnings)
 if [ $PYLINT_EXIT -ne 0 ] && [ $PYLINT_EXIT -ne 30 ]; then
 	echo "Commit failed: pylint checks did not pass."
-	echo "You can find the files that failed linting in $TEMP_DIR"
+	echo "You can find the files that failed linting in $PYLINT_DIR"
 	exit 1
 else
 	cleanup


### PR DESCRIPTION
Previously we had a situation that could occur which would allow for unlinted files to be commited if they previously failed the pre-commit hook then were corrected but not staged. This would effectivly allow an unlinted file to be commited.

This change will create a temp dir, and copy the files to the temp dir this way we only lint the files that have been staged. If it fails the temp dir is left intact so that it can be inspected by the user. Once it gets a successful run it'll clean itself up.